### PR TITLE
Use AwsClient.endpoint inside S3Client.signed_upload_url

### DIFF
--- a/aioaws/core.py
+++ b/aioaws/core.py
@@ -87,7 +87,7 @@ class AwsClient:
         data: Optional[bytes] = None,
         content_type: Optional[str] = None,
     ) -> Response:
-        url = URL(f'https://{self.host}{path}', params=[(k, v) for k, v in sorted((params or {}).items())])
+        url = URL(f'{self.endpoint}{path}', params=[(k, v) for k, v in sorted((params or {}).items())])
         r = await self.client.request(
             method,
             url,

--- a/aioaws/s3.py
+++ b/aioaws/s3.py
@@ -151,7 +151,7 @@ class S3Client:
         https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
         """
         assert not path.startswith('/'), 'path should not start with /'
-        url = URL(f'https://{self._aws_client.host}/{path}')
+        url = URL(f'{self._aws_client.endpoint}/{path}')
         url = self._aws_client.add_signed_download_params('GET', url, max_age)
         if version:
             url = url.copy_add_param('v', version)
@@ -201,7 +201,7 @@ class S3Client:
             'Policy': b64_policy,
             **self._aws_client.signed_upload_fields(now, b64_policy),
         }
-        return dict(url=f'https://{self._aws_client.host}/', fields=fields)
+        return dict(url=f'{self._aws_client.endpoint}/', fields=fields)
 
 
 def to_key(sf: Union[S3File, str]) -> str:


### PR DESCRIPTION
The current implementation does not allow mocking s3 with localstack via an http connection, rather than https.

This change honours any manual changes to `AwsClient.endpoint` after the `S3Client` is instantiated.

