### PR TITLE
Allow HTTP S3 Endpoints

### DIFF
--- a/aioaws/_types.py
+++ b/aioaws/_types.py
@@ -5,8 +5,9 @@ class BaseConfigProtocol(Protocol):
     aws_access_key: str
     aws_secret_key: str
     aws_region: str
-    # aws_host is optional and will be inferred if omitted
+    # aws_host and aws_host_scheme are optional and will be inferred if omitted
     # aws_host: str
+    # aws_host_schema: str
 
 
 class S3ConfigProtocol(Protocol):

--- a/aioaws/core.py
+++ b/aioaws/core.py
@@ -48,7 +48,11 @@ class AwsClient:
                 else:
                     # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html
                     self.host = f'{bucket}.s3.{self.region}.amazonaws.com'
-        self.schema = 'https'
+        try:
+            self.schema = get_config_attr(config, 'aws_host_schema')
+
+        except TypeError:
+            self.schema = 'https'
 
         self._auth = AWSv4Auth(
             aws_secret_key=self.aws_secret_key,

--- a/aioaws/s3.py
+++ b/aioaws/s3.py
@@ -34,6 +34,7 @@ class S3Config:
     aws_s3_bucket: str
     # custom host to connect with
     aws_host: Optional[str] = None
+    aws_host_schema: Optional[str] = None
 
 
 class S3File(BaseModel):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -17,9 +17,7 @@ run_prefix = secrets.token_hex()[:10]
 
 def test_upload_url_after_overriding_aws_client_endpoint(mocker):
     mocker.patch('aioaws.s3.utcnow', return_value=datetime(2032, 1, 1))
-    s3 = S3Client('-', S3Config('testing', 'testing', 'testing', 'testing.com'))
-    s3._aws_client.host = 'localhost:4766'
-    s3._aws_client.schema = 'http'
+    s3 = S3Client('-', S3Config('testing', 'testing', 'testing', 'testing.com', 'localhost:4766', 'http'))
     d = s3.signed_upload_url(
         path='testing/', filename='test.png', content_type='image/png', size=123, expires=datetime(2032, 1, 1)
     )


### PR DESCRIPTION
I'm currently developing a service which will be using SeaweedFS as an S3 drop in replacement, and I'd prefer to use this library over aiohttp-s3-client as I'm building a FastAPI app, and httpx is already included for the test client. However, the SeaweedFS instance will be running in a kubernetes node and likely won't have SSL. The only way to use an http endpoint atm seem to be modifying `S3Client._aws_client.schema` similar to [one of your tests](https://github.com/samuelcolvin/aioaws/blob/main/tests/test_s3.py#L18), but this isn't exactly ideal. This change allows configuration of `AwsClient.schema`.

If modifying the config isn't desired, it could be changed to use [yarl](https://github.com/aio-libs/yarl) to parse the provided URL and, if a scheme is provided, assign it to `AwsClient.schema`. Off the top of my head:

```
parsed_url = URL(self.host)
if parsed_url.scheme:
    self.schema = parsed_url.scheme
    self.host = str(parsed_url).replace(f'{parsed_url.scheme}://', '')

else:
    self.schema = 'https'
```

I may be missing it, but unfortunately, yarl doesn't seem to have any helper methods to get the URL without the scheme.