### PR TITLE
strip .com suffix from bucket_name in S3 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ from httpx import AsyncClient
 from devtools import debug
 
 async def s3_demo(client: AsyncClient):
-    s3 = S3Client(client, S3Config('<access key>', '<secret key>', '<region>', 'my_bucket_name.com'))
+    s3 = S3Client(client, S3Config('<access key>', '<secret key>', '<region>', '<my_bucket_name>'))
 
     # upload a file:
     await s3.upload('path/to/upload-to.txt', b'this the content')


### PR DESCRIPTION
Using ".com" in the readme example for "my_bucket_name" arg in S3Config is misleading. 

Error when including ".com" suffix on bucket name: `httpcore.ConnectError: [Errno -2] Name or service not known`