### PR TITLE
Basic DynamoDB support

### DIFF
--- a/aioaws/_types.py
+++ b/aioaws/_types.py
@@ -14,3 +14,11 @@ class S3ConfigProtocol(Protocol):
     aws_secret_key: str
     aws_region: str
     aws_s3_bucket: str
+
+
+class DynamoDBConfigProtocol(Protocol):
+    aws_access_key: str
+    aws_secret_key: str
+    aws_region: str
+    # aws_host is optional and will be inferred if omitted
+    # aws_host: str

--- a/aioaws/core.py
+++ b/aioaws/core.py
@@ -203,7 +203,7 @@ class AWSv4Auth:
         canonical_request_parts = (
             method,
             url_quote(url.path),
-            url.query.decode(),
+            url.query.decode().replace('/', '%2F'),
             ''.join(f'{k}:{headers[k]}\n' for k in header_keys),
             signed_headers,
             payload_hash,

--- a/aioaws/dynamodb.py
+++ b/aioaws/dynamodb.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+import json
+from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, Optional, Union
+from httpx import AsyncClient
+from .core import AwsClient, RequestError
+
+if TYPE_CHECKING:
+    from ._types import DynamoDBConfigProtocol
+
+__all__ = ('DynamoDBClient',)
+
+
+@dataclass
+class DynamoDBConfig:
+    aws_access_key: str
+    aws_secret_key: str
+    aws_region: str
+    # custom host to connect with
+    aws_host: Optional[str] = None
+
+
+class DynamoDBClient:
+    __slots__ = '_config', '_aws_client'
+
+    def __init__(self, http_client: AsyncClient, config: "DynamoDBConfigProtocol"):
+        self._aws_client = AwsClient(http_client, config, 'dynamodb')
+        self._config = config
+
+    async def put_item(self, table_name: str, item: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Put an item into the specified DynamoDB table.
+        """
+        payload = {"TableName": table_name, "Item": item}
+        response = await self._aws_client.post(
+            "/",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Content-Type": "application/x-amz-json-1.0",
+                "X-Amz-Target": "DynamoDB_20120810.PutItem",
+            },
+        )
+        return response.json()
+
+    async def delete_item(self, table_name: str, key: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Delete an item from the specified DynamoDB table.
+        """
+        payload = {"TableName": table_name, "Key": key}
+        response = await self._aws_client.post(
+            "/",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Content-Type": "application/x-amz-json-1.0",
+                "X-Amz-Target": "DynamoDB_20120810.DeleteItem",
+            },
+        )
+        return response.json()
+
+    async def get_item(self, table_name: str, key: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Get an item from the specified DynamoDB table.
+        """
+        payload = {"TableName": table_name, "Key": key}
+        response = await self._aws_client.post(
+            "/",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Content-Type": "application/x-amz-json-1.0",
+                "X-Amz-Target": "DynamoDB_20120810.GetItem",
+            },
+        )
+        return response.json()
+
+    async def query(
+        self, table_name: str, expression: str, expression_values: Dict[str, Any], **kwargs: Any
+    ) -> AsyncIterable[Dict[str, Any]]:
+        """
+        Query the specified DynamoDB table and return an async iterable.
+        """
+        last_evaluated_key = None
+        while True:
+            payload = {
+                "TableName": table_name,
+                "KeyConditionExpression": expression,
+                "ExpressionAttributeValues": expression_values,
+                **kwargs,
+            }
+            if last_evaluated_key:
+                payload["ExclusiveStartKey"] = last_evaluated_key
+
+            response = await self._aws_client.post(
+                "/",
+                data=json.dumps(payload).encode(),
+                headers={
+                    "Content-Type": "application/x-amz-json-1.0",
+                    "X-Amz-Target": "DynamoDB_20120810.Query",
+                }
+            )
+            response_data = response.json()
+
+            # Yield the items from the current batch of results
+            for item in response_data.get('Items', []):
+                yield item
+
+            # If there's more data, set the last_evaluated_key for the next loop iteration
+            last_evaluated_key = response_data.get('LastEvaluatedKey')
+            if not last_evaluated_key:
+                break  # No more items left to query

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "aiofiles>=0.5.0",
     "cryptography>=3.1.1",
     "httpx>=0.23.3",
-    "pydantic>=1.8.2",
+    "pydantic>=1.8.2,<2.0.0",
 ]
 dynamic = ["version"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,7 @@ class CustomAsyncClient(AsyncClient):
             else:
                 return new_url.copy_with(path='/status/200/')
         else:
-            # return url
-            raise ValueError(f'no local endpoint found for "{url}"')
+            return new_url
 
 
 @pytest.fixture(name='client')

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1,0 +1,68 @@
+"""Test DynamoDB client."""
+
+from foxglove.test_server import DummyServer
+from httpx import AsyncClient
+import pytest
+
+from aiohttp import ClientSession
+
+from aioaws.dynamodb import DynamoDBClient, DynamoDBConfig
+
+
+@pytest.mark.asyncio
+async def test_dynamodb(client: AsyncClient, aws: DummyServer):
+    """Test DynamoDB client."""
+    dynamodb_client = DynamoDBClient(client, DynamoDBConfig("testing", "testing", "testing", "testing"))
+    await dynamodb_client.put_item(
+        "test-table",
+        {
+            "id": {"S": "123"},
+            "name": {"S": "test"},
+            "description": {"S": "test description"},
+        },
+    )
+    response = await dynamodb_client.get_item("test-table", {"id": {"S": "123"}})
+    assert response["Item"]["name"]["S"] == "test"
+    await dynamodb_client.delete_item("test-table", {"id": {"S": "123"}})
+    response = await dynamodb_client.get_item("test-table", {"id": {"S": "123"}})
+    assert "Item" not in response
+
+
+@pytest.mark.asyncio
+async def test_query(client: AsyncClient, aws: DummyServer):
+    """Test DynamoDB query."""
+    dynamodb_client = DynamoDBClient(
+        client,
+        DynamoDBConfig(
+            "testing",
+            "testing",
+            "testing",
+            "testing",
+        ),
+    )
+    await dynamodb_client.put_item(
+        "test-table",
+        {
+            "id": {"S": "123"},
+            "name": {"S": "test"},
+            "description": {"S": "test description"},
+        },
+    )
+    async for item in dynamodb_client.query(
+        "test-table",
+        "id = :id",
+        {
+            ":id": {"S": "123"},
+        },
+    ):
+        assert item["name"]["S"] == "test"
+        break
+    await dynamodb_client.delete_item("test-table", {"id": {"S": "123"}})
+    async for item in dynamodb_client.query(
+        "test-table",
+        "id = :id",
+        {
+            ":id": {"S": "123"},
+        },
+    ):
+        assert False, "should not get here"


### PR DESCRIPTION
This PR adds basic DynamoDB support, including `GetItem`, `PutItem`, `DeleteItem`, and `Query`.

We're working with AWS Lambda and have been frustrated by the slow initialization on cold start when using `boto3`. I'm hoping to be able to use this library to speed things up a bit. We are using DynamoDB so hence this contribution. I hacked this together pretty quickly and am still working to validate it but I figured I'd get a draft PR open at least.

It's been a bit since this project has seen updates. I'm interested to know whether you're open to these kinds of contributions and whether you'll be doing much work in or adjacent to this library in the near future -- for instance, if we're happy with this PR, how long I could expect to wait before we can see this in a release. I don't mean to presume too much, just curious.

Thanks! I appreciate your work and consideration for these changes.